### PR TITLE
Casting user_id to an int

### DIFF
--- a/src/SignedRequest.php
+++ b/src/SignedRequest.php
@@ -96,7 +96,7 @@ class SignedRequest
 	 */
 	public function getUserId(): ?int
 	{
-		return $this->get('user_id');
+		return (int)$this->get('user_id');
 	}
 
 


### PR DESCRIPTION
Since the graph call returns a string but the function is typed to return an int we need to cast it